### PR TITLE
Wrap schema and table names

### DIFF
--- a/lib/queries.js
+++ b/lib/queries.js
@@ -8,14 +8,14 @@ module.exports = function queries () {
     'where nspname = ANY($1)',
 
     // List of tables
-    'select table_schema, table_name, obj_description((table_schema||\'.\'||table_name)::regclass, \'pg_class\') table_comment ' +
+    'select table_schema, table_name, obj_description((\'"\' || table_schema || \'"."\' || table_name || \'"\')::regclass, \'pg_class\') table_comment ' +
     'from information_schema.tables ' +
     'where table_schema = ANY($1)' +
     'and table_type = \'BASE TABLE\'',
 
     // List of columns
     'select table_schema, table_name, column_name, column_default, is_nullable, data_type, character_maximum_length, numeric_scale, ' +
-    'pg_catalog.col_description(format(\'%s.%s\',isc.table_schema,isc.table_name)::regclass::oid,isc.ordinal_position) as column_comment, udt_name as array_element_type ' +
+    'pg_catalog.col_description(format(\'"%s"."%s"\',isc.table_schema,isc.table_name)::regclass::oid,isc.ordinal_position) as column_comment, udt_name as array_element_type ' +
     'from information_schema.columns isc ' +
     'where table_schema = ANY($1) ' +
     'order by ordinal_position',
@@ -25,7 +25,7 @@ module.exports = function queries () {
     'from information_schema.tables t, pg_index i ' +
     'join pg_attribute a on a.attrelid = i.indrelid ' +
     'and a.attnum = any(i.indkey) ' +
-    'where i.indrelid = (t.table_schema||\'.\'||t.table_name)::regclass ' +
+    'where i.indrelid = (\'"\' || t.table_schema||\'"."\'||t.table_name || \'"\')::regclass ' +
     'and i.indisprimary ' +
     'and t.table_schema = any($1)',
 


### PR DESCRIPTION
This is an update to queries for supporting table and schema names in camel case.

e.g. 
Schemas with names like `mySchema` and tables with names like `someTable`