### PR TITLE
Make order of database queries predictable 

### DIFF
--- a/lib/queries.js
+++ b/lib/queries.js
@@ -5,20 +5,22 @@ module.exports = function queries () {
     // List of schemas
     'select nspname as schema_name, obj_description(oid) as schema_comment ' +
     'from pg_namespace ' +
-    'where nspname = ANY($1)',
+    'where nspname = ANY($1) ' +
+    'order by nspname',
 
     // List of tables
     'select table_schema, table_name, obj_description((\'"\' || table_schema || \'"."\' || table_name || \'"\')::regclass, \'pg_class\') table_comment ' +
     'from information_schema.tables ' +
     'where table_schema = ANY($1)' +
-    'and table_type = \'BASE TABLE\'',
+    'and table_type = \'BASE TABLE\' ' +
+    'order by table_schema, table_name',
 
     // List of columns
     'select table_schema, table_name, column_name, column_default, is_nullable, data_type, character_maximum_length, numeric_scale, ' +
     'pg_catalog.col_description(format(\'"%s"."%s"\',isc.table_schema,isc.table_name)::regclass::oid,isc.ordinal_position) as column_comment, udt_name as array_element_type ' +
     'from information_schema.columns isc ' +
     'where table_schema = ANY($1) ' +
-    'order by ordinal_position',
+    'order by table_schema, table_name, ordinal_position',
 
     // List of primary keys
     'select a.attname pk_column_name, t.table_schema, t.table_name ' +
@@ -27,7 +29,8 @@ module.exports = function queries () {
     'and a.attnum = any(i.indkey) ' +
     'where i.indrelid = (\'"\' || t.table_schema||\'"."\'||t.table_name || \'"\')::regclass ' +
     'and i.indisprimary ' +
-    'and t.table_schema = any($1)',
+    'and t.table_schema = any($1) ' +
+    'order by t.table_schema, t.table_name, a.attname',
 
     // List of indexes
     'SELECT ' +
@@ -50,10 +53,11 @@ module.exports = function queries () {
     'ON i.relam = am.oid ' +
     'JOIN pg_namespace AS NS ON i.relnamespace = NS.OID ' +
     'JOIN pg_user AS U ON i.relowner = U.usesysid ' +
-    'WHERE ns.nspname = ANY($1)',
+    'WHERE ns.nspname = ANY($1) ' +
+    'ORDER BY 1, 2, 3',
 
     // List of foreign key constraints
-    'SELECT constraint_name,split_part(source_table, \'.\', 1) AS source_schema, source_table, source_column, target_table, target_column, update_action, delete_action, match_type FROM ' +
+    'SELECT constraint_name, split_part(source_table, \'.\', 1) AS source_schema, source_table, source_column, target_table, target_column, update_action, delete_action, match_type FROM ' +
     '(SELECT constraint_name,source_table::regclass::text AS source_table, source_attr.attname AS source_column, ' +
     'target_table::regclass::text, target_attr.attname AS target_column, update_action, delete_action, match_type ' +
     'FROM pg_attribute target_attr, pg_attribute source_attr, ' +
@@ -67,21 +71,25 @@ module.exports = function queries () {
     ') query2 ' +
     'WHERE target_attr.attnum = target_constraints AND target_attr.attrelid = target_table ' +
     'AND source_attr.attnum = source_constraints AND source_attr.attrelid = source_table) AS fk_constraints ' +
-    'WHERE split_part(source_table, \'.\', 1) = ANY($1)',
+    'WHERE split_part(source_table, \'.\', 1) = ANY($1) ' +
+    'ORDER BY 2, 3, 1',
 
     // List of triggers
     'SELECT trigger_name, trigger_schema, event_object_schema, event_object_table, event_manipulation, action_condition, action_statement, action_orientation, action_timing ' +
     'FROM information_schema.triggers ' +
-    'WHERE trigger_schema = ANY($1)',
+    'WHERE trigger_schema = ANY($1) ' +
+    'ORDER BY trigger_name',
 
     // List of functions
     'SELECT * ' +
     'FROM information_schema.routines ' +
-    'WHERE specific_schema = ANY($1)',
+    'WHERE specific_schema = ANY($1) ' +
+    'ORDER BY specific_name',
 
     // List of views
     'select table_schema as view_schema, table_name as view_name, obj_description((\'"\' || table_schema || \'"."\' || table_name || \'"\')::regclass, \'pg_class\') view_comment, view_definition ' +
     'from information_schema.views ' +
-    'where table_schema = ANY($1)'
+    'where table_schema = ANY($1) ' +
+    'order by table_schema, table_name'
   ]
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -25,7 +25,7 @@ describe('Run the basic-usage example', function () {
   let client
 
   before(function () {
-    if (process.env.PG_CONNECTION_STRING && !/^postgres:\/\/[^:]+:[^@]+@(?:localhost|127\.0\.0\.1).*$/.test(process.env.PG_CONNECTION_STRING)) {
+    if (process.env.PG_CONNECTION_STRING && !/^postgres:\/\/[^:]+:(.)*(?:localhost|127\.0\.0\.1).*$/.test(process.env.PG_CONNECTION_STRING)) {
       console.log(`Skipping tests due to unsafe PG_CONNECTION_STRING value (${process.env.PG_CONNECTION_STRING})`)
       this.skip()
     }
@@ -46,7 +46,7 @@ describe('Run the basic-usage example', function () {
     it('get database info (callback)', function (done) {
       pgInfo(
         {
-          client: client,
+          client,
           schemas: schemaNames
         },
         function (err, info) {
@@ -59,7 +59,7 @@ describe('Run the basic-usage example', function () {
 
     it('get database info (promise)', (done) => {
       pgInfo({
-        client: client,
+        client,
         schemas: schemaNames
       })
         .then(info => {
@@ -75,7 +75,7 @@ describe('Run the basic-usage example', function () {
 
     it('get database info (await)', async () => {
       const info = await pgInfo({
-        client: client,
+        client,
         schemas: schemaNames
       })
 


### PR DESCRIPTION
Hi WMFS! :fire_engine:

**What a great project! :heart:**

Please find my tiny PR for your consideration... you'll see it adds additional `order by` clauses to introspection-queries which omit them.

* This provides a lot more predictability for packages which use `pg-info` (e.g. code-generation output, diff-processing etc.)

